### PR TITLE
Fix the condition to check if data is loaded

### DIFF
--- a/MMM-Pronote.js
+++ b/MMM-Pronote.js
@@ -103,7 +103,7 @@ Module.register("MMM-Pronote", {
 
   updateData: function(data) {
     this.userData = data
-    if (!this.userData.name) {
+    if (Object.keys(this.userData).length === 0) {
       this.log ("Error... no data!")
       this.error = "Erreur... Aucune données"
       return


### PR DESCRIPTION
Vu qu'on ne load que ce dont on a besoin dans le node_helper, la condition pour vérifier que les données sont chargées n'était plus bonne (si jamais on n'affiche pas le nom de l'élève).